### PR TITLE
Collapse unnecessary accordions by default

### DIFF
--- a/hyperspy_gui_ipywidgets/axes.py
+++ b/hyperspy_gui_ipywidgets/axes.py
@@ -118,23 +118,20 @@ def ipy_axes_gui(obj, **kwargs):
     wdict = {}
     nav_widgets = []
     sig_widgets = []
-    i = 0
-    for axis in obj.navigation_axes:
+    for i, axis in enumerate(obj.navigation_axes):
         wd = _get_axis_widgets(axis, display=False)
-        nav_widgets.append(wd["widget"])
+        accord = ipywidgets.Accordion([wd["widget"]])
+        accord.set_title(0, "Axis {}".format(i))
+        nav_widgets.append(accord)
         wdict["axis{}".format(i)] = wd["wdict"]
-        i += 1
     for j, axis in enumerate(obj.signal_axes):
         wd = _get_axis_widgets(axis, display=False)
-        sig_widgets.append(wd["widget"])
-        wdict["axis{}".format(i + j)] = wd["wdict"]
-    nav_accordion = ipywidgets.Accordion(nav_widgets)
-    sig_accordion = ipywidgets.Accordion(sig_widgets)
-    i = 0  # For when there is not navigation axes
-    for i in range(obj.navigation_dimension):
-        nav_accordion.set_title(i, "Axis %i" % i)
-    for j in range(obj.signal_dimension):
-        sig_accordion.set_title(j, "Axis %i" % (i + j + 1))
+        accord = ipywidgets.Accordion([wd["widget"]])
+        accord.set_title(0, "Axis {}".format(i + j + 1))
+        sig_widgets.append(accord)
+        wdict["axis{}".format(i + j + 1)] = wd["wdict"]
+    nav_accordion = ipywidgets.VBox(nav_widgets)
+    sig_accordion = ipywidgets.VBox(sig_widgets)
     tabs = ipywidgets.HBox([nav_accordion, sig_accordion])
     return {
         "widget": tabs,

--- a/hyperspy_gui_ipywidgets/model.py
+++ b/hyperspy_gui_ipywidgets/model.py
@@ -257,6 +257,7 @@ def fit_component_ipy(obj, **kwargs):
     wdict["help"] = only_current
     help = Accordion(children=[help])
     help.set_title(0, "Help")
+    help.selected_index = None # Collapse accordion
     link((obj, "only_current"), (only_current, "value"))
     fit = Button(
         description="Fit",

--- a/hyperspy_gui_ipywidgets/tools.py
+++ b/hyperspy_gui_ipywidgets/tools.py
@@ -24,6 +24,7 @@ def interactive_range_ipy(obj, **kwargs):
         "range. Press `Apply` to perform the operation or `Close` to cancel.",)
     help = ipywidgets.Accordion(children=[help])
     help.set_title(0, "Help")
+    help.selected_index = None # Collapse accordion
     close = ipywidgets.Button(
         description="Close",
         tooltip="Close widget and remove span selector from the signal figure.")
@@ -88,6 +89,7 @@ def calibrate_ipy(obj, **kwargs):
     wdict["help"] = help
     help = ipywidgets.Accordion(children=[help])
     help.set_title(0, "Help")
+    help.selected_index = None # Collapse accordion
     close = ipywidgets.Button(
         description="Close",
         tooltip="Close widget and remove span selector from the signal figure.")
@@ -355,6 +357,7 @@ def image_constast_editor_ipy(obj, **kwargs):
     wdict["help"] = help
     help = ipywidgets.Accordion(children=[help])
     help.set_title(0, "Help")
+    help.selected_index = None # Collapse accordion
     close = ipywidgets.Button(
         description="Close",
         tooltip="Close widget and remove span selector from the signal figure.")
@@ -417,6 +420,7 @@ def remove_background_ipy(obj, **kwargs):
     wdict["help"] = help
     help = ipywidgets.Accordion(children=[help])
     help.set_title(0, "Help")
+    help.selected_index = None # Collapse accordion
     close = ipywidgets.Button(
         description="Close",
         tooltip="Close widget and remove span selector from the signal figure.")
@@ -487,6 +491,7 @@ def spikes_removal_ipy(obj, **kwargs):
         value=SPIKES_REMOVAL_INSTRUCTIONS.replace('\n', '<br/>'))
     help = ipywidgets.Accordion(children=[help])
     help.set_title(0, "Help")
+    help.selected_index = None # Collapse accordion
 
     show_diff = ipywidgets.Button(
         description="Show derivative histogram",
@@ -563,6 +568,7 @@ def spikes_removal_ipy(obj, **kwargs):
             labelme("Spline order", spline_order), ]),))
 
     advanced.set_title(0, "Advanced settings")
+    advanced.selected_index = None # Collapse accordion
     box = ipywidgets.VBox([
         ipywidgets.VBox([
             show_diff,


### PR DESCRIPTION
I've set the default appearance of any Help and Advanced accordions to be closed. 
I've also fixed #4 by turning axes_manager.gui() into multiple accordions instead of just one.