### PR TITLE
Fix installing travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install:
     - pip install --upgrade pip
     - pip install https://github.com/hyperspy/link_traits/archive/master.zip
     - pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_minor.zip
-    - pip install .[test]
+    - pip install ipywidgets
+    - pip install --no-deps .
     - export MPLBACKEND=agg
     - pip install pytest-cov codecov --upgrade
 script:


### PR DESCRIPTION
Install hyperspy_gui_ipywidgets separately and specify `--no-deps` during pip installing to avoid dependency failure comparison with hyperspy development version (for example 1.4dev is not >= 1.4).

An alternative would be to set the hyperspy dependency to `1.4dev` instead of `1.4` in setup.py.

With travis CI fixed, it seems that python 3.4 is not happy with the changes introduced in https://github.com/hyperspy/hyperspy/pull/1870: 

```bash
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/config.py", line 325, in _getconftestmodules
    return self._path2confmods[path]
KeyError: local('/home/travis/build/ericpre/hyperspy_gui_ipywidgets/hyperspy_gui_ipywidgets')
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/config.py", line 356, in _importconftest
    return self._conftestpath2mod[conftestpath]
KeyError: local('/home/travis/build/ericpre/hyperspy_gui_ipywidgets/hyperspy_gui_ipywidgets/conftest.py')
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/_pytest/config.py", line 362, in _importconftest
    mod = conftestpath.pyimport()
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/py/_path/local.py", line 662, in pyimport
    __import__(modname)
  File "/home/travis/build/ericpre/hyperspy_gui_ipywidgets/hyperspy_gui_ipywidgets/__init__.py", line 3, in <module>
    import hyperspy.api_nogui # necessary to register the toolkeys
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/hyperspy/api_nogui.py", line 75, in <module>
    from hyperspy import signals
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/hyperspy/signals.py", line 42, in <module>
    from hyperspy.signal import BaseSignal
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/hyperspy/signal.py", line 35, in <module>
    from hyperspy.axes import AxesManager
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/hyperspy/axes.py", line 956
    **dict.fromkeys(['left',  dim0_decrease, '4'], (0, -1)),
     ^
SyntaxError: invalid syntax
ERROR: could not load /home/travis/build/ericpre/hyperspy_gui_ipywidgets/hyperspy_gui_ipywidgets/conftest.py
```