### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: python
 python:
     - "nightly"
     - 3.5
-    - 3.4
-    - 3.6-dev
+    - 3.6
 sudo: false
 install:
     - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ sudo: false
 install:
     - pip install --upgrade pip
     - pip install https://github.com/hyperspy/link_traits/archive/master.zip
-    - pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_minor.zip
+    - pip install https://github.com/francisco-dlp/hyperspy/archive/RELEASE_v1.4.zip
     - pip install .[test]
     - export MPLBACKEND=agg
     - pip install pytest-cov codecov --upgrade

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.0',
+    version='1.1.0.dev',
 
     description=('ipywidgets GUI elements for HyperSpy.'),
     long_description=long_description,
@@ -67,7 +67,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['hyperspy>=1.4', 'ipywidgets>=6.0', 'link_traits'],
+    install_requires=['hyperspy>=1.4.dev', 'ipywidgets>=6.0', 'link_traits'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
This hopefully fixes the failing tests by:

* Setting the requirement to hyperspy >=1.4.dev
* Pointing to the v1.4 release branch were code that broke the ipywidgtets was reverted