### PR TITLE
Fix pandoc error during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ here = path.abspath(path.dirname(__file__))
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
-except ImportError:
+    # if pandoc is not installed: raise an OSError
+except (ImportError, OSError):
     with open(path.join(here, 'README.md'), encoding='utf-8') as f:
         long_description = f.read()
 


### PR DESCRIPTION
When pandoc is not installed, an `OSError` is raised and needs to be caught accordingly. This is the case for more recent release of winpython [>= 2008-01](https://github.com/winpython/winpython/blob/master/changelogs/WinPythonQt5-64bit-3.6.5.0_History.md).