### PR TITLE
Fix bug parameter widget 

### DIFF
--- a/hyperspy_gui_ipywidgets/model.py
+++ b/hyperspy_gui_ipywidgets/model.py
@@ -26,7 +26,8 @@ def _interactive_slider_bounds(obj, index=None):
     if _min is None and _max is not None:
         _min = value - pad
     if _min is None and _max is None:
-        if obj.component and obj is obj.component._position:
+        if obj.component and obj is obj.component._position and \
+                obj._axes_manager is not None:
             axis = obj._axes_manager.signal_axes[-1]
             _min = axis.axis.min()
             _max = axis.axis.max()


### PR DESCRIPTION
Fix bug breaking the parameter widget when the component is not added to a model. 

```python
import hyperspy.api as hs
pl = hs.model.components1D.PowerLaw()
pl.origin.gui()
```
makes the error:
```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-eb046172203a> in <module>
----> 1 pl.origin.gui()

~/Dev/hyperspy/hyperspy/ui_registry.py in pg(self, display, toolkit, **kwargs)
    172     def pg(self, display=True, toolkit=None, **kwargs):
    173         return get_gui(self, toolkey=toolkey, display=display,
--> 174                        toolkit=toolkit, **kwargs)
    175     return pg
    176 

~/Dev/hyperspy/hyperspy/ui_registry.py in get_gui(self, toolkey, display, toolkit, **kwargs)
    152         if toolkit in toolkits:
    153             used_toolkits.add(toolkit)
--> 154             thisw = f(obj=self, display=display, **kwargs)
    155             if not display:
    156                 widgets[toolkit] = thisw

~/Dev/hyperspy_gui_ipywidgets/hyperspy_gui_ipywidgets/utils.py in wrapper(*args, **kwargs)
     77     def wrapper(*args, **kwargs):
     78         display = kwargs.pop("display", True)
---> 79         wdict = f(*args, **kwargs)
     80         if display:
     81             IPython.display.display(wdict["widget"])

~/Dev/hyperspy_gui_ipywidgets/hyperspy_gui_ipywidgets/model.py in get_parameter_widget(obj, **kwargs)
    107     """
    108     if obj._number_of_elements == 1:
--> 109         return _get_value_widget(obj)
    110     else:
    111         wdict = {}

~/Dev/hyperspy_gui_ipywidgets/hyperspy_gui_ipywidgets/model.py in _get_value_widget(obj, index)
     42 def _get_value_widget(obj, index=None):
     43     wdict = {}
---> 44     widget_bounds = _interactive_slider_bounds(obj, index=index)
     45     thismin = FloatText(value=widget_bounds['min'],
     46                         description='min',

~/Dev/hyperspy_gui_ipywidgets/hyperspy_gui_ipywidgets/model.py in _interactive_slider_bounds(obj, index)
     28     if _min is None and _max is None:
     29         if obj.component and obj is obj.component._position:
---> 30             axis = obj._axes_manager.signal_axes[-1]
     31             _min = axis.axis.min()
     32             _max = axis.axis.max()

AttributeError: 'NoneType' object has no attribute 'signal_axes'
```