### PR TITLE
Fix deprecation warning

### DIFF
--- a/hyperspy_gui_ipywidgets/axes.py
+++ b/hyperspy_gui_ipywidgets/axes.py
@@ -39,8 +39,7 @@ def ipy_navigation_sliders(obj, **kwargs):
         link((axis, "scale"), (vwidget, "step"))
         name = ipywidgets.Label(str(axis),
                                 layout=ipywidgets.Layout(width="15%"))
-        units = ipywidgets.Label(layout=ipywidgets.Layout(width="5%"),
-                                 disabled=True)
+        units = ipywidgets.Label(layout=ipywidgets.Layout(width="5%"))
         link((axis, "name"), (name, "value"))
         link((axis, "units"), (units, "value"))
         bothw = ipywidgets.HBox([name, iwidget, vwidget, units])

--- a/hyperspy_gui_ipywidgets/model.py
+++ b/hyperspy_gui_ipywidgets/model.py
@@ -134,8 +134,7 @@ def get_parameter_widget(obj, **kwargs):
                 vwidget.value = value
         update.on_click(on_update_clicked)
         wdict["update_button"] = update
-        container = Accordion([VBox([update] + par_widgets)],
-                              descrition=obj.name)
+        container = Accordion([VBox([update] + par_widgets)])
         container.set_title(0, obj.name)
 
     return {

--- a/hyperspy_gui_ipywidgets/preferences.py
+++ b/hyperspy_gui_ipywidgets/preferences.py
@@ -9,34 +9,34 @@ from hyperspy_gui_ipywidgets.utils import (
 
 
 def bool2checkbox(trait, label):
-    tooltip = trait.desc if trait.desc else ""
+    description_tooltip = trait.desc if trait.desc else ""
     widget = ipywidgets.Checkbox(
-        tooltip=tooltip,
+        description_tooltip=description_tooltip,
     )
     return labelme(widget=widget, label=label)
 
 
 def directory2unicode(trait, label):
-    tooltip = trait.desc if trait.desc else ""
+    description_tooltip = trait.desc if trait.desc else ""
     widget = ipywidgets.Text(
-        tooltip=tooltip,)
+        description_tooltip=description_tooltip,)
     return labelme(widget=widget, label=label)
 
 
 def enum2dropdown(trait, label):
-    tooltip = trait.desc if trait.desc else ""
+    description_tooltip = trait.desc if trait.desc else ""
     widget = ipywidgets.Dropdown(
         options=trait.trait_type.values,
-        tooltip=tooltip,)
+        description_tooltip=description_tooltip,)
     return labelme(widget=widget, label=label)
 
 
 def range2floatrangeslider(trait, label):
-    tooltip = trait.desc if trait.desc else ""
+    description_tooltip = trait.desc if trait.desc else ""
     widget = ipywidgets.FloatSlider(
         min=trait.trait_type._low,
         max=trait.trait_type._high,
-        tooltip=tooltip,)
+        description_tooltip=description_tooltip,)
     return labelme(widget=widget, label=label)
 
 # Trait types must be converted to the appropriate ipywidget

--- a/hyperspy_gui_ipywidgets/preferences.py
+++ b/hyperspy_gui_ipywidgets/preferences.py
@@ -71,8 +71,7 @@ def show_preferences_widget(obj, **kwargs):
         ipytabs[tab] = ipywidgets.VBox(ipytab)
     titles = ["General", "GUIs", "Plot", "EELS", "EDS"]
     ipytabs_ = ipywidgets.Tab(
-        children=[ipytabs[title.replace(" ", "")] for title in titles],
-        titles=titles)
+        children=[ipytabs[title.replace(" ", "")] for title in titles])
     for i, title in enumerate(titles):
         ipytabs_.set_title(i, title)
     save_button = ipywidgets.Button(

--- a/hyperspy_gui_ipywidgets/preferences.py
+++ b/hyperspy_gui_ipywidgets/preferences.py
@@ -1,5 +1,3 @@
-import traitlets
-import traits.api as t
 import traits
 import ipywidgets
 
@@ -24,10 +22,8 @@ def directory2unicode(trait, label):
 
 
 def enum2dropdown(trait, label):
-    description_tooltip = trait.desc if trait.desc else ""
     widget = ipywidgets.Dropdown(
-        options=trait.trait_type.values,
-        description_tooltip=description_tooltip,)
+        options=trait.trait_type.values)
     return labelme(widget=widget, label=label)
 
 
@@ -38,6 +34,7 @@ def range2floatrangeslider(trait, label):
         max=trait.trait_type._high,
         description_tooltip=description_tooltip,)
     return labelme(widget=widget, label=label)
+
 
 # Trait types must be converted to the appropriate ipywidget
 TRAITS2IPYWIDGETS = {

--- a/hyperspy_gui_ipywidgets/preferences.py
+++ b/hyperspy_gui_ipywidgets/preferences.py
@@ -69,9 +69,10 @@ def show_preferences_widget(obj, **kwargs):
             link((getattr(obj, tab), trait_name),
                  (widget.children[1], "value"))
         ipytabs[tab] = ipywidgets.VBox(ipytab)
+    # This defines the order of the tab in the widget
     titles = ["General", "GUIs", "Plot", "EELS", "EDS"]
     ipytabs_ = ipywidgets.Tab(
-        children=[ipytabs[title.replace(" ", "")] for title in titles])
+        children=[ipytabs[title] for title in titles])
     for i, title in enumerate(titles):
         ipytabs_.set_title(i, title)
     save_button = ipywidgets.Button(

--- a/hyperspy_gui_ipywidgets/utils.py
+++ b/hyperspy_gui_ipywidgets/utils.py
@@ -46,11 +46,13 @@ def get_label(trait, label):
     return label
 
 
-def enum2dropdown(trait):
-    description_tooltip = trait.desc if trait.desc else ""
+def enum2dropdown(trait, description=None):
     widget = ipywidgets.Dropdown(
-        options=trait.trait_type.values,
-        description_tooltip=description_tooltip,)
+        options=trait.trait_type.values)
+    if description is not None:
+        tooltip = trait.desc if trait.desc else ""
+        widget.description = description
+        widget.description_tooltip = tooltip
     return widget
 
 

--- a/hyperspy_gui_ipywidgets/utils.py
+++ b/hyperspy_gui_ipywidgets/utils.py
@@ -47,10 +47,10 @@ def get_label(trait, label):
 
 
 def enum2dropdown(trait):
-    tooltip = trait.desc if trait.desc else ""
+    description_tooltip = trait.desc if trait.desc else ""
     widget = ipywidgets.Dropdown(
         options=trait.trait_type.values,
-        tooltip=tooltip,)
+        description_tooltip=description_tooltip,)
     return widget
 
 

--- a/hyperspy_gui_ipywidgets/utils.py
+++ b/hyperspy_gui_ipywidgets/utils.py
@@ -55,9 +55,9 @@ def enum2dropdown(trait):
 
 
 def float2floattext(trait, label):
-    tooltip = trait.desc if trait.desc else ""
+    description = trait.desc if trait.desc else ""
     widget = ipywidgets.FloatText(
-        tooltip=tooltip,
+        description=description,
     )
     return labelme(widget=widget, label=label)
 

--- a/hyperspy_gui_ipywidgets/utils.py
+++ b/hyperspy_gui_ipywidgets/utils.py
@@ -55,9 +55,9 @@ def enum2dropdown(trait):
 
 
 def float2floattext(trait, label):
-    description = trait.desc if trait.desc else ""
+    description_tooltip = trait.desc if trait.desc else ""
     widget = ipywidgets.FloatText(
-        description=description,
+        description_tooltip=description_tooltip,
     )
     return labelme(widget=widget, label=label)
 


### PR DESCRIPTION
Fix deprecation warning, which may raise error in future release of traitlets:
- [x] Remove `disabled` argument at initialisation of  `Label` widget,
- [x] Remove `descrition` argument at initialisation of `Accordion` widget,
- [x] Rename `tooltip` to `description_tooltip` for `Checkbox`, `Text`, `FloatText` and `FloatSlider` widgets,
- [x] Remove `description_tooltip` in `Dropdown` widgets,
- [x] Remove `titles` argument to the `Tab`, the titles come from the children widgets.