### PR TITLE
A widget to display a table for EELS edges

### DIFF
--- a/hyperspy_gui_ipywidgets/hyperspy_extension.yaml
+++ b/hyperspy_gui_ipywidgets/hyperspy_extension.yaml
@@ -25,6 +25,9 @@ GUI:
       hyperspy.EELSCLEdge_Component:
         module: hyperspy_gui_ipywidgets.model
         function: get_eelscl_widget
+      hyperspy.EELSSpectrum.print_edges_table:
+        module: hyperspy_gui_ipywidgets.tools
+        function: print_edges_table_ipy
       hyperspy.ScalableFixedPattern_Component:
         module: hyperspy_gui_ipywidgets.model
         function: get_scalable_fixed_patter_widget

--- a/hyperspy_gui_ipywidgets/tests/test_tools.py
+++ b/hyperspy_gui_ipywidgets/tests/test_tools.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import hyperspy.api as hs
 from hyperspy_gui_ipywidgets.tests.utils import KWARGS
-from hyperspy.signal_tools import Signal1DCalibration, ImageContrastEditor
+from hyperspy.signal_tools import (Signal1DCalibration, ImageContrastEditor,
+                                   EdgesRange)
 
 
 class TestTools:
@@ -223,3 +224,30 @@ class TestTools:
         wd["reset_button"]._click_handlers(wd["reset_button"])    # Trigger it
         assert im._plot.signal_plot.vmin == '0.0th'
         assert im._plot.signal_plot.vmax == '100.0th'
+
+    def test_eels_table_tool(self):
+        s = hs.datasets.artificial_data.get_core_loss_eels_line_scan_signal(True)
+        s.plot()
+        er = EdgesRange(s)
+
+        er.ss_left_value = 500
+        er.ss_right_value = 550
+
+        wd = er.gui(**KWARGS)["ipywidgets"]["wdict"]
+        wd["update"]._click_handlers(wd["update"])  # refresh the table
+        assert wd["units"].value == 'eV'
+        assert wd["left"].value == 500
+        assert wd["right"].value == 550
+        assert len(wd['gb'].children) == 36 # 9 edges displayed
+
+        wd['major'].value = True
+        wd["update"]._click_handlers(wd["update"])  # refresh the table
+        assert len(wd['gb'].children) == 24 # 6 edges displayed
+        assert wd['gb'].children[4].description == 'Sb_M4'
+
+        wd['order'].value = 'ascending'
+        wd["update"]._click_handlers(wd["update"])  # refresh the table
+        assert wd['gb'].children[4].description == 'V_L3'
+
+        wd["reset"]._click_handlers(wd["reset"])  # reset the selector
+        assert len(wd['gb'].children) == 4 # only header displayed

--- a/hyperspy_gui_ipywidgets/tools.py
+++ b/hyperspy_gui_ipywidgets/tools.py
@@ -167,13 +167,17 @@ def print_edges_table_ipy(obj, **kwargs):
                                 disabled=False,
                                 style={'description_width': 'initial'}
                                 )
+    edges_list = ipywidgets.SelectMultiple(rows=10, description='Show edge(s)',
+                                           disabled=False,
+                                           style={'description_width': 'initial'})
     table = ipywidgets.interactive_output(obj.show_edges_table, 
                                           {'x0': left,
                                            'x1': right,
                                            'only_major': major,
                                            'update': update,
-                                           'order': order}
-                                          ) 
+                                           'order': order,
+                                           'active_edges': edges_list}
+                                          )
     help = ipywidgets.HTML(
         "Click on the signal figure and drag to the right to select a signal "
         "range. Drag the rectangle or change its border to display edges in "
@@ -188,16 +192,18 @@ def print_edges_table_ipy(obj, **kwargs):
     wdict["major"] = major
     wdict["update"] = update
     wdict["order"] = order
+    wdict["edges_list"] = edges_list
     wdict["table"] = table
 
     # Connect
     link((obj, "ss_left_value"), (left, "value"))
     link((obj, "ss_right_value"), (right, "value"))
     link((axis, "units"), (units, "value"))
+    link((obj, "edges_list"), (edges_list, "options"))
 
     energy_box = ipywidgets.HBox([left, units, ipywidgets.Label("-"), right, 
                                   units])
-    control_box = ipywidgets.VBox([energy_box, order, update, major])
+    control_box = ipywidgets.VBox([energy_box, order, update, major, edges_list])
 
     box = ipywidgets.VBox([
         ipywidgets.HBox([table, control_box]),

--- a/hyperspy_gui_ipywidgets/tools.py
+++ b/hyperspy_gui_ipywidgets/tools.py
@@ -260,7 +260,7 @@ def print_edges_table_ipy(obj, **kwargs):
     def on_reset_clicked(b):
         # ss_left_value is linked with left.value, this can prevent cyclic
         # referencing
-        obj._clear_all_markers()
+        obj._clear_markers()
         obj.span_selector_switch(False)
         left.value = 0
         right.value = 0

--- a/hyperspy_gui_ipywidgets/tools.py
+++ b/hyperspy_gui_ipywidgets/tools.py
@@ -161,11 +161,18 @@ def print_edges_table_ipy(obj, **kwargs):
                                 indent=False)
     update = ipywidgets.Checkbox(value=True, description='Update table',
                                  indent=False)
+    order = ipywidgets.Dropdown(options=['closest', 'ascending', 'descending'],
+                                value='closest',
+                                description='Sort energy by: ',
+                                disabled=False,
+                                style={'description_width': 'initial'}
+                                )
     table = ipywidgets.interactive_output(obj.show_edges_table, 
                                           {'x0': left,
                                            'x1': right,
                                            'only_major': major,
-                                           'update': update}
+                                           'update': update,
+                                           'order': order}
                                           ) 
     help = ipywidgets.HTML(
         "Click on the signal figure and drag to the right to select a signal "
@@ -180,6 +187,7 @@ def print_edges_table_ipy(obj, **kwargs):
     wdict["help"] = help
     wdict["major"] = major
     wdict["update"] = update
+    wdict["order"] = order
     wdict["table"] = table
 
     # Connect
@@ -189,7 +197,7 @@ def print_edges_table_ipy(obj, **kwargs):
 
     energy_box = ipywidgets.HBox([left, units, ipywidgets.Label("-"), right, 
                                   units])
-    control_box = ipywidgets.VBox([energy_box, update, major])
+    control_box = ipywidgets.VBox([energy_box, order, update, major])
 
     box = ipywidgets.VBox([
         ipywidgets.HBox([table, control_box]),

--- a/hyperspy_gui_ipywidgets/tools.py
+++ b/hyperspy_gui_ipywidgets/tools.py
@@ -169,18 +169,18 @@ def print_edges_table_ipy(obj, **kwargs):
                                 disabled=False,
                                 style=style_d
                                 )
-    update = ipywidgets.Button(description='Update', layout={'width': 'initial'})
+    update = ipywidgets.Button(description='Refresh table', layout={'width': 'initial'})
     gb = ipywidgets.GridBox(layout=ipywidgets.Layout(
-            grid_template_columns="70px 125px 75px 250px")) 
+            grid_template_columns="70px 125px 75px 250px"))
     help = ipywidgets.HTML(
         "Click on the signal figure and drag to the right to select a signal "
         "range. Drag the rectangle or change its border to display edges in "
-        "different signal range. Select edges to show their positions " 
+        "different signal range. Select edges to show their positions "
         "on the signal.",)
-    help = ipywidgets.Accordion(children=[help])
+    help = ipywidgets.Accordion(children=[help], selected_index=None)
     help.set_title(0, "Help")
     close = ipywidgets.Button(description="Close", tooltip="Close the widget.")
-    reset = ipywidgets.Button(description="Reset", 
+    reset = ipywidgets.Button(description="Reset",
                               tooltip="Reset the span selector.")
 
     header = ('<p style="padding-left: 1em; padding-right: 1em; '
@@ -213,9 +213,9 @@ def print_edges_table_ipy(obj, **kwargs):
         edges, energy, relevance, description = obj.update_table()
 
         # header
-        items = [ipywidgets.HTML(header.format('edge')), 
-                 ipywidgets.HTML(header.format('onset energy (eV)')), 
-                 ipywidgets.HTML(header.format('relevance')), 
+        items = [ipywidgets.HTML(header.format('edge')),
+                 ipywidgets.HTML(header.format('onset energy (eV)')),
+                 ipywidgets.HTML(header.format('relevance')),
                  ipywidgets.HTML(header.format('description'))]
 
         # rows
@@ -228,7 +228,7 @@ def print_edges_table_ipy(obj, **kwargs):
                 btn_state = False
 
             btn = ipywidgets.ToggleButton(value=btn_state,
-                                          description=edge, 
+                                          description=edge,
                                           layout=ipywidgets.Layout(width='70px'))
             btn.observe(obj.update_active_edge,  names='value')
             obj.btns.append(btn)
@@ -246,7 +246,7 @@ def print_edges_table_ipy(obj, **kwargs):
         obj.update_table()
         obj.check_btn_state()
     complmt.observe(on_complementary_toggled)
-    
+
     def on_order_changed(change):
         obj._get_edges_info_within_energy_axis()
         update_table(change)
@@ -268,7 +268,7 @@ def print_edges_table_ipy(obj, **kwargs):
         update_table(b)
     reset.on_click(on_reset_clicked)
 
-    energy_box = ipywidgets.HBox([left, units, ipywidgets.Label("-"), right, 
+    energy_box = ipywidgets.HBox([left, units, ipywidgets.Label("-"), right,
                                    units])
     check_box = ipywidgets.HBox([major, complmt])
     control_box = ipywidgets.VBox([energy_box, update, order, check_box])

--- a/hyperspy_gui_ipywidgets/tools.py
+++ b/hyperspy_gui_ipywidgets/tools.py
@@ -195,9 +195,8 @@ def print_edges_table_ipy(obj, **kwargs):
     help = ipywidgets.Accordion(children=[help])
     help.set_title(0, "Help")
     close = ipywidgets.Button(description="Close", tooltip="Close the widget.")
-    reset = ipywidgets.Button(description="Reset selector", 
+    reset = ipywidgets.Button(description="Reset", 
                               tooltip="Reset the span selector.")
-
 
     wdict["left"] = left
     wdict["right"] = right
@@ -210,6 +209,8 @@ def print_edges_table_ipy(obj, **kwargs):
     wdict["edges_list"] = edges_list
     wdict["comp_edges_list"] = comp_edges_list
     wdict["table"] = table
+    wdict["reset"] = reset
+    wdict["close"] = close
 
     # Connect
     link((obj, "ss_left_value"), (left, "value"))
@@ -242,6 +243,15 @@ def print_edges_table_ipy(obj, **kwargs):
         box.close()
     close.on_click(on_close_clicked)
 
+    def on_reset_clicked(b):
+        # ss_left_value is linked with left.value, this can prevent cyclic
+        # referencing
+        obj.span_selector_switch(False)
+        left.value = 0
+        right.value = 0
+        obj.span_selector_switch(True)
+    reset.on_click(on_reset_clicked)
+
     energy_box = ipywidgets.HBox([left, units, ipywidgets.Label("-"), right, 
                                   units])
     check_box = ipywidgets.HBox([update, major, complmt])
@@ -251,7 +261,7 @@ def print_edges_table_ipy(obj, **kwargs):
     box = ipywidgets.VBox([
         ipywidgets.HBox([table, control_box]),
         help,
-        close
+        ipywidgets.HBox([reset, close]),
     ])
 
     return {

--- a/hyperspy_gui_ipywidgets/tools.py
+++ b/hyperspy_gui_ipywidgets/tools.py
@@ -155,15 +155,16 @@ def print_edges_table_ipy(obj, **kwargs):
     wdict = {}
     axis = obj.axis
     style_d = {'description_width': 'initial'}
-    left = ipywidgets.FloatText(disabled=True, layout={'width': '10%'})
-    right = ipywidgets.FloatText(disabled=True, layout={'width': '10%'})
+    layout_d = {'width': '50%'}
+    left = ipywidgets.FloatText(disabled=True, layout={'width': '25%'})
+    right = ipywidgets.FloatText(disabled=True, layout={'width': '25%'})
     units = ipywidgets.Label(style=style_d)
     major = ipywidgets.Checkbox(value=False, description='Only major edge',
-                                indent=False, layout={'width': '50%'})
+                                indent=False, layout=layout_d)
     update = ipywidgets.Checkbox(value=True, description='Update table',
-                                 indent=False, layout={'width': '50%'})
+                                 indent=False, layout=layout_d)
     complmt = ipywidgets.Checkbox(value=False, description='Complementary edge',
-                                 indent=False, layout={'width': '50%'})
+                                 indent=False, layout=layout_d)
     order = ipywidgets.Dropdown(options=['closest', 'ascending', 'descending'],
                                 value='closest',
                                 description='Sort energy by: ',
@@ -171,10 +172,12 @@ def print_edges_table_ipy(obj, **kwargs):
                                 style=style_d
                                 )
     edges_list = ipywidgets.SelectMultiple(rows=10, description='Show edge(s)',
-                                           disabled=False, style=style_d, layout={'width': '50%'})
+                                           disabled=False, style=style_d, 
+                                           layout=layout_d)
     comp_edges_list = ipywidgets.SelectMultiple(rows=10, disabled=False,
                                                 description='Other edge(s)',
-                                                style=style_d, layout={'width': '50%'})
+                                                style=style_d, 
+                                                layout=layout_d)
     table = ipywidgets.interactive_output(obj.show_edges_table, 
                                           {'x0': left,
                                            'x1': right,
@@ -182,14 +185,19 @@ def print_edges_table_ipy(obj, **kwargs):
                                            'update': update,
                                            'order': order,
                                            'active_edges': edges_list,
-                                           'show_complmt': complmt}
+                                           'complementary': complmt}
                                           )
     help = ipywidgets.HTML(
         "Click on the signal figure and drag to the right to select a signal "
         "range. Drag the rectangle or change its border to display edges in "
-        "different signal range.",)
+        "different signal range. Select edges to show their positions " 
+        "on the signal.",)
     help = ipywidgets.Accordion(children=[help])
     help.set_title(0, "Help")
+    close = ipywidgets.Button(description="Close", tooltip="Close the widget.")
+    reset = ipywidgets.Button(description="Reset selector", 
+                              tooltip="Reset the span selector.")
+
 
     wdict["left"] = left
     wdict["right"] = right
@@ -197,6 +205,7 @@ def print_edges_table_ipy(obj, **kwargs):
     wdict["help"] = help
     wdict["major"] = major
     wdict["update"] = update
+    wdict["complmt"] = complmt
     wdict["order"] = order
     wdict["edges_list"] = edges_list
     wdict["comp_edges_list"] = comp_edges_list
@@ -228,15 +237,21 @@ def print_edges_table_ipy(obj, **kwargs):
         obj._plot_labels(active=obj.active_edges, complementary=complementary)
     comp_edges_list.observe(comp_edges_list_handler, names='value')
 
+    def on_close_clicked(b):
+        obj.span_selector_switch(False)
+        box.close()
+    close.on_click(on_close_clicked)
+
     energy_box = ipywidgets.HBox([left, units, ipywidgets.Label("-"), right, 
-                                  units, order])
+                                  units])
     check_box = ipywidgets.HBox([update, major, complmt])
     edge_box = ipywidgets.HBox([edges_list, comp_edges_list])
-    control_box = ipywidgets.VBox([energy_box, check_box, edge_box])
+    control_box = ipywidgets.VBox([energy_box, order, check_box, edge_box])
 
     box = ipywidgets.VBox([
         ipywidgets.HBox([table, control_box]),
-        help  
+        help,
+        close
     ])
 
     return {

--- a/hyperspy_gui_ipywidgets/tools.py
+++ b/hyperspy_gui_ipywidgets/tools.py
@@ -149,6 +149,57 @@ def calibrate_ipy(obj, **kwargs):
         "wdict": wdict,
     }
 
+@add_display_arg
+def print_edges_table_ipy(obj, **kwargs):
+    # Define widgets
+    wdict = {}
+    axis = obj.axis
+    left = ipywidgets.FloatText(disabled=True, layout={'width': '20%'})
+    right = ipywidgets.FloatText(disabled=True, layout={'width': '20%'})
+    units = ipywidgets.Label(style={'description_width': 'initial'})
+    major = ipywidgets.Checkbox(value=False, description='Only major edge',
+                                indent=False)
+    update = ipywidgets.Checkbox(value=True, description='Update table',
+                                 indent=False)
+    table = ipywidgets.interactive_output(obj.show_edges_table, 
+                                          {'x0': left,
+                                           'x1': right,
+                                           'only_major': major,
+                                           'update': update}
+                                          ) 
+    help = ipywidgets.HTML(
+        "Click on the signal figure and drag to the right to select a signal "
+        "range. Drag the rectangle or change its border to display edges in "
+        "different signal range.",)
+    help = ipywidgets.Accordion(children=[help])
+    help.set_title(0, "Help")
+
+    wdict["left"] = left
+    wdict["right"] = right
+    wdict["units"] = units
+    wdict["help"] = help
+    wdict["major"] = major
+    wdict["update"] = update
+    wdict["table"] = table
+
+    # Connect
+    link((obj, "ss_left_value"), (left, "value"))
+    link((obj, "ss_right_value"), (right, "value"))
+    link((axis, "units"), (units, "value"))
+
+    energy_box = ipywidgets.HBox([left, units, ipywidgets.Label("-"), right, 
+                                  units])
+    control_box = ipywidgets.VBox([energy_box, update, major])
+
+    box = ipywidgets.VBox([
+        ipywidgets.HBox([table, control_box]),
+        help  
+    ])
+
+    return {
+        "widget": box,
+        "wdict": wdict,
+    }
 
 @add_display_arg
 def smooth_savitzky_golay_ipy(obj, **kwargs):


### PR DESCRIPTION
This include a widget to display a table for EELS edges, from an energy within selected by a span selector. Edges can be marked by selecting them in the list. See hyperspy/hyperspy#2418.