### PR TITLE
Increase required version of ipywidgets to 7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['hyperspy>=1.6', 'ipywidgets>=6.0', 'link_traits'],
+    install_requires=['hyperspy>=1.6', 'ipywidgets>=7.0', 'link_traits'],
 
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
The `style` argument was passed to `FloatProgress`, however this parameter is not present in ipywidget 6.0.0. This leads to `AttributeErrors`.

ipywidgets 7.0.0 was released in August 2017, so it should be in all python distributions.