### PR TITLE
Fix issue with entry_points when installing editable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
   See https://keepachangelog.com for details
 
 ## v2.1 (UNRELEASED)
+* Fix regression with editable installation ([#55](https://github.com/hyperspy/hyperspy_gui_ipywidgets/pull/55)).
 
 ## v2.0 (2023-11-15)
 * Consolidate package metadata in `pyproject.toml` ([#49](https://github.com/hyperspy/hyperspy_gui_ipywidgets/pull/49)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.entry-points."hyperspy.extensions"]
-hyperspy-gui-ipywidgets = "hyperspy_gui_ipywidgets"
+hyperspy_gui_ipywidgets = "hyperspy_gui_ipywidgets"
 
 [project.license]
 file = "LICENSE"


### PR DESCRIPTION
When trying to install HyperSpy + HyperSpy plotting extensions (traitsui and ipywidgets) in editable mode, there is an issue with the entry_points.

To replicate (only tested in Ubuntu 23.10):

- In a virtual environment in miniforge, first install "stable" HyperSpy (conda install hyperspy).
- Run in python terminal `import hyperspy.api as hs` (which works nicely)
- Then use `pip3 install -e .` in `hyperspy_gui_ipywidgets` project folder
- Run in python terminal `import hyperspy.api as hs`

This gives this error:

Specifically, it looks is the wrong folder:  
```python
FileNotFoundError: [Errno 2] No such file or directory: '/.../hyperspy_gui_ipywidgets/hyperspy-gui-ipywidgets/hyperspy_extension.yaml'
```

When it should look in (note the underscores): `'/.../hyperspy_gui_ipywidgets/hyperspy_gui_ipywidgets/hyperspy_extension.yaml'`

One way to fix this is by changing in `pyproject.toml`:

``python
hyperspy-gui-ipywidgets = "hyperspy_gui_ipywidgets"
```

to

```python
hyperspy_gui_ipywidgets = "hyperspy_gui_ipywidgets"
```

However, I am not sure how this will affect other installation methods.

----------

Note: this also affects `hyperspy_gui_traitsui` in a similar way